### PR TITLE
Fix trailing slash issue in Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-COPY *.go .
+COPY *.go ./
 
 RUN go build -o /docker-gs-ping-roach
 


### PR DESCRIPTION
Fixes a bug described in olliefr/docker-gs-ping#1