### PR TITLE
update golang and debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ## Build
 ##
 
-FROM golang:1.16-buster AS build
+FROM golang:1.19-buster AS build
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN go build -o /docker-gs-ping-roach
 ## Deploy
 ##
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian11
 
 WORKDIR /
 


### PR DESCRIPTION
Hi there!

This is the issue that I encounter when running build command, due to old version of golang:1.16 in Dockerfile:

```
 => [build 6/7] COPY *.go ./                                                             0.4s
 => ERROR [build 7/7] RUN go build -o /docker-gs-ping-roach                              3.3s
------
 > [build 7/7] RUN go build -o /docker-gs-ping-roach:
#14 3.109 main.go:14:2: //go:build comment without // +build comment
------
executor failed running [/bin/sh -c go build -o /docker-gs-ping-roach]: exit code: 1
```

Could you update please?